### PR TITLE
Updated LTS300 stage Steps Per Rev to reflect the real Trinomics encoder values, i.e. multiplied them by 2048.

### DIFF
--- a/thorpy/comm/discovery.py
+++ b/thorpy/comm/discovery.py
@@ -12,7 +12,7 @@ def discover_stages():
             continue
         
         if platform.system() == 'Linux':
-            port_candidates = [x[0] for x in serial_ports if x[2].get('SNR', None) == dev.serial_number]
+            port_candidates = [x[0] for x in serial_ports if x[2].get('SER', None) == dev.serial_number]
         else:
             raise NotImplementedError("Implement for platform.system()=={0}".format(platform.system()))
         

--- a/thorpy/stages/MG17APTServer.ini
+++ b/thorpy/stages/MG17APTServer.ini
@@ -1390,6 +1390,7 @@ Encoder 1uStep Wnd=10
 Encoder Stop Short Dist=250
 Encoder Corr Move Dist=5
 Encoder Calib Step=0.2
+
 Encoder Calib Dwell=50
 Encoder QEP Sense=-1
 
@@ -2399,6 +2400,7 @@ Jog Max Vel=0.3
 Jog Stop Mode=2
 Steps Per Rev=48
 Gearbox Ratio=256
+
 Encoder Fitted=0
 DC Servo=1
 DC Prop=435
@@ -3706,7 +3708,7 @@ Jog Min Vel=0.0
 Jog Accn=2.5
 Jog Max Vel=5.0
 Jog Stop Mode=2
-Steps Per Rev=200
+Steps Per Rev=409600
 Gearbox Ratio=1
 Encoder Fitted=0
 FP Controls=1
@@ -4995,6 +4997,7 @@ Home Dir=2
 Home Limit Switch=1
 Home Vel=1
 Home Zero Offset=0.1
+
 Jog Mode=2
 Jog Step Size=0.5
 Jog Min Vel=0.0
@@ -5782,7 +5785,7 @@ Jog Min Vel=0.0
 Jog Accn=10.0
 Jog Max Vel=10.0
 Jog Stop Mode=2
-Steps Per Rev=200
+Steps Per Rev=409600
 Gearbox Ratio=1
 Encoder Fitted=0
 FP Controls=1
@@ -6029,6 +6032,7 @@ Pot Wnd 2=80
 Pot Vel 3=0.75
 Pot Wnd 3=100
 Pot Vel 4=1.0
+
 Button Mode=1
 Button Pos 1=0
 Button Pos 2=6.5

--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -449,10 +449,16 @@ class GenericStage:
             if not self.status_in_motion_forward and not self.status_in_motion_reverse:
                 self._port.send_message(MGMSG_MOT_MOVE_HOME(chan_ident = self._chan_ident))
             time.sleep(1)
-            
-            
+
         return True
-            
+
+    def home_non_blocking(self, force = True ):
+        if self.status_homed and not force:
+            return True
+        
+        self._port.send_message(MGMSG_MOT_MOVE_HOME(chan_ident = self._chan_ident))     
+        return True
+
     def _wait_for_properties(self, properties, timeout = None, message = None, message_repeat_timeout = None):
         start_time = time.time()
         last_message_time = 0

--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -222,7 +222,7 @@ class GenericStage:
     
     @property
     def position(self):
-        self._wait_for_properties(('_state_position', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_position', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return self._state_position / self._EncCnt
 
     @position.setter
@@ -233,72 +233,72 @@ class GenericStage:
 
     @property
     def velocity(self):
-        self._wait_for_properties(('_state_velocity', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_velocity', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return self._state_velocity / (self._EncCnt * self._T)  #Dropped the 65536 factor, which resulted in false results
 
     @property
     def status_forward_hardware_limit_switch_active(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000001) != 0
 
     @property
     def status_reverse_hardware_limit_switch_active(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000002) != 0
 
     @property
     def status_in_motion_forward(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000010) != 0
 
     @property
     def status_in_motion_reverse(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000020) != 0
 
     @property
     def status_in_motion_jogging_forward(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000040) != 0
 
     @property
     def status_in_motion_jogging_reverse(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000080) != 0
 
     @property
     def status_in_motion_homing(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000200) != 0
 
     @property
     def status_homed(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00000400) != 0
 
     @property
     def status_tracking(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00001000) != 0
 
     @property
     def status_settled(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00002000) != 0
 
     @property
     def status_motion_error(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x00004000) != 0
 
     @property
     def status_motor_current_limit_reached(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x01000000) != 0
 
     @property
     def status_channel_enabled(self):
-        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_DCSTATUSUPDATE(chan_ident = self._chan_ident))
+        self._wait_for_properties(('_state_status_bits', ), timeout = 3, message = MGMSG_MOT_REQ_STATUSUPDATE(chan_ident = self._chan_ident))
         return (self._state_status_bits & 0x80000000) != 0
     
     #VELPARAMS


### PR DESCRIPTION
The APT Communications Protocol Rev 16, page 18, states as follows:

"The BSC20x series and MST602 stepper controllers include a Trinamics encoder with a
resolution of 2048 microsteps per full step, giving 409600 micro-steps per revolution for a
200 step motor."

This means that the motor has 200 steps, but there are actually 200x2048 'micro'steps through which it is controlled. Hence the configuration values for steps per revolution need to be multiplied by 2048. Otherwise everything is way off.

With this correction, the stage moves properly, i.e. 's.position = 150.0' will move the LTS300 half way through (150mm). Also the displayed settings for acceleration and velocity are scaled properly to sensible values. Further information on the effect of the various stage status values is provided below.

Without correction:

"Stage: HS LTS300 300mm Stage
Position: 0.000mm
Status: homed, channel enabled
Velocity parameters: velocity: 0.000-98285.279mm/s, acceleration: 58981.750mm/s²
Homing parameters: velocity: 8964.141mm/s, direction: 2, limit_switch: 1, offset_distance: 0.000mm"

With correction:

"Stage: HS LTS300 300mm Stage
Position: 0.000mm
Status: homed, channel enabled
Velocity parameters: velocity: 0.000-47.991mm/s, acceleration: 28.800mm/s²
Homing parameters: velocity: 4.377mm/s, direction: 2, limit_switch: 1, offset_distance: 0.000mm"

Final note: perhaps the configuration parameter 'Encoder Fitted' was intended to allow for this kind of conversion factor? In any case, it does not seem to be used at the moment so I modified the 'Steps per Rev' directly.
