### PR TITLE
Tdc001 z812b

### DIFF
--- a/thorpy/comm/port.py
+++ b/thorpy/comm/port.py
@@ -215,8 +215,8 @@ class SingleControllerPort(Port):
         if msg is None:
             return msg
         
-        assert msg.source == 0x50
-        assert msg.dest == 0x01
+        #assert msg.source == 0x50
+        #assert msg.dest == 0x01
         return msg
 
     def _handle_message(self, msg):

--- a/thorpy/message/_base.py
+++ b/thorpy/message/_base.py
@@ -61,7 +61,7 @@ class Message:
     def dest(self, destination_id):
         if destination_id is not None:
             assert isinstance(destination_id, int)
-            assert 0 < destination_id < 0x80
+            assert 0 <= destination_id <= 0x80
         self._dest = destination_id
 
     @property
@@ -72,7 +72,7 @@ class Message:
     def source(self, source_id):
         if source_id is not None:
             assert isinstance(source_id, int)
-            assert 0 < source_id < 0x80
+            assert 0 <= source_id <= 0x80
         self._source = source_id
 
     @classproperty

--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -20,7 +20,7 @@ def stage_name_from_get_hw_info(m):
             return 'HS ZST6(B)'
         else:
             return 'ZST6(B)'
-    elif controller_type in (27, 63, 83):
+    elif controller_type in (27, 63, 83, 2197):
         #Info obtained from thorlabs technical support
         if stage_type == 0x01:
             _print_stage_detection_improve_message(m)


### PR DESCRIPTION
My Thorlabs apt - dc servo controller `TDC001` with a `Z812B` servo stage always reports `0x80` as `dest` and `0x00` as `source`. Therefore, I removed the assertions for `dest` and `source`. Also, it reports `2197` as `controller_type`. Everything works for me now.