### PR TITLE
Discover controllers by serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Thorpy
+# Thorpy
 
 Python library implementing Thorlabs APT communication protocol
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 setup(name="thorpy",
       version="0.0.0",
       description="",
-      packages = ['thorpy', 'thorpy.comm', 'thorpy.message', 'thorpy.stages'],
+      packages = ['thorpy', 'thorpy.comm', 'thorpy.message', 'thorpy.stages','thorpy.flipmount'],
       package_data = {'thorpy.stages': ['*.ini']},
       include_package_data = True,
       zip_safe = True,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 setup(name="thorpy",
       version="0.0.0",
       description="",
-      packages = ['thorpy', 'thorpy.comm', 'thorpy.message', 'thorpy.stages'],
+      packages = ['thorpy', 'thorpy.comm', 'thorpy.message', 'thorpy.stages', 'thorpy.flipmount'],
       package_data = {'thorpy.stages': ['*.ini']},
       include_package_data = True,
       zip_safe = True,

--- a/thorpy/comm/port.py
+++ b/thorpy/comm/port.py
@@ -55,7 +55,9 @@ class Port:
             except: # TODO: Be more specific on what we catch here
                 self._buffer = b''
                 self._serial.flushInput()
-                
+#        print(self._info_message['serial_number'])
+#        self._info_message.__serial_number = sn
+#        print(self._info_message)
         self._serial_number = int(sn)
         if self._serial_number is None:
             self._serial_number = self._info_message['serial_number']
@@ -244,7 +246,7 @@ class SingleControllerPort(Port):
         ret = dict([(k, self._stages.get(k, None)) for k in only_chan_idents])
         for k in only_chan_idents:
             if ret[k] is None:
-                ret[k] = GenericStage(self, 0x01, stage_name_from_get_hw_info(self._info_message))
+                ret[k] = GenericStage(self, 0x01, stage_name_from_get_hw_info(self._info_message, self._serial_number))
                 self._stages[k] = ret[k]
                 
         return ret

--- a/thorpy/flipmount/flipmount.py
+++ b/thorpy/flipmount/flipmount.py
@@ -1,0 +1,30 @@
+import thorpy.comm.discovery as thc
+
+class flipMount:
+
+    def __init__(self, sn):
+        self.__stage = thc.discover_stages(sn)
+
+    def identify(self):
+        self.__stage.identify()
+
+    def open(self):
+        self.__stage.move_jog_forward()
+
+    def close(self):
+        self.__stage.move_jog_backward()
+
+    def is_open(self):
+        return self.__stage.status_forward_hardware_limit_switch_active
+
+    def is_close(self):
+        return self.__stage.status_reverse_hardware_limit_switch_active
+
+    def is_moving(self):
+        return self.__stage.status_in_motion_forward
+
+    def flip(self):
+        if self.is_open():
+            self.close()
+        else:
+            self.open()

--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -10,8 +10,12 @@ def _print_stage_detection_improve_message(m):
           '- stage type\n' + \
           '- this data: {0}'.format(m), file = sys.stderr)
 
-def stage_name_from_get_hw_info(m):
-    controller_type = m['serial_number'] // 1000000  #v7
+def stage_name_from_get_hw_info(m, sn=None):
+    if sn is None:
+        controller_type = m['serial_number'] // 1000000  #v7
+    else:
+        controller_type = int(sn) // 1000000  #v7
+
     stage_type = m['empty_space'][-2]  #Reverse engineered
     hw_version = m['hw_version']
     model_number = m['model_number'].decode('ascii').strip('\x00')

--- a/thorpy/stages/__init__.py
+++ b/thorpy/stages/__init__.py
@@ -164,7 +164,7 @@ class GenericStage:
         
         self._port.send_message(MGMSG_MOD_SET_CHANENABLESTATE(chan_ident = self._chan_ident, chan_enable_state = 0x01))
         
-        print("Constructed: {0!r}".format(self))
+        print("Test: "+"Constructed: {0!r}".format(self))
         
         #STATUSUPDATE
         self._state_position = None
@@ -474,7 +474,18 @@ class GenericStage:
         
     def __repr__(self):
         return '<{0} on {1!r} channel {2}>'.format(self._name, self._port, self._chan_ident)
-        
+ 
+
+    def identify(self):
+        self._port.send_message(MGMSG_MOD_IDENTIFY())
+
+    def move_jog_forward(self):
+        self._port.send_message(MGMSG_MOT_MOVE_JOG(chan_ident = self._chan_ident, direction = 0x01))
+
+    def move_jog_backward(self):
+        self._port.send_message(MGMSG_MOT_MOVE_JOG(chan_ident = self._chan_ident, direction = 0x02))
+
+       
 
 #Message which should maybe be implemented?
 #Should be in port: MGMSG_HUB_REQ_BAYUSED, MGMSG_HUB_GET_BAYUSED,


### PR DESCRIPTION
As most of motor controllers will be used in groups controlling more than one axis, it is important to bind to the right one so that X and Y axes are not swapped. 

This pull request adds one positional parameter to the ```discover_stages``` function that ensures this. 